### PR TITLE
lower some severities to see the important ones more easily

### DIFF
--- a/src/validators/check_name.rs
+++ b/src/validators/check_name.rs
@@ -20,7 +20,7 @@ pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
         .feed_info
         .iter()
         .filter(|&feed_info| !has_name(&*feed_info))
-        .map(|_feed_info| Issue::new(Severity::Error, IssueType::MissingName, ""));
+        .map(|_feed_info| Issue::new(Severity::Warning, IssueType::MissingName, ""));
     route_issues
         .chain(stop_issues)
         .chain(agency_issues)
@@ -33,7 +33,7 @@ fn has_name<T: std::fmt::Display>(o: &T) -> bool {
 }
 
 fn make_missing_name_issue<T: gtfs_structures::Id + gtfs_structures::Type>(o: &T) -> Issue {
-    Issue::new(Severity::Error, IssueType::MissingName, o.id()).object_type(o.object_type())
+    Issue::new(Severity::Warning, IssueType::MissingName, o.id()).object_type(o.object_type())
 }
 
 #[test]

--- a/src/validators/coordinates.rs
+++ b/src/validators/coordinates.rs
@@ -27,7 +27,7 @@ fn make_invalid_coord_issue<T: gtfs_structures::Id + gtfs_structures::Type + std
 fn make_missing_coord_issue<T: gtfs_structures::Id + gtfs_structures::Type + std::fmt::Display>(
     o: &T,
 ) -> Issue {
-    Issue::new_with_obj(Severity::Error, IssueType::MissingCoordinates, o)
+    Issue::new_with_obj(Severity::Warning, IssueType::MissingCoordinates, o)
 }
 
 fn missing_coord_details(stop: &gtfs_structures::Stop) -> &str {

--- a/src/validators/duplicate_stops.rs
+++ b/src/validators/duplicate_stops.rs
@@ -40,7 +40,7 @@ fn make_duplicate_stops_issue<
 >(
     o: &T,
 ) -> Issue {
-    Issue::new_with_obj(Severity::Error, IssueType::DuplicateStops, o)
+    Issue::new_with_obj(Severity::Information, IssueType::DuplicateStops, o)
 }
 
 #[test]

--- a/src/validators/duration_distance.rs
+++ b/src/validators/duration_distance.rs
@@ -47,8 +47,12 @@ fn validate_speeds(
 
             if distance < 10.0 {
                 result.push(
-                    Issue::new_with_obj(Severity::Warning, IssueType::CloseStops, &*departure.stop)
-                        .add_related_object(&*arrival.stop),
+                    Issue::new_with_obj(
+                        Severity::Information,
+                        IssueType::CloseStops,
+                        &*departure.stop,
+                    )
+                    .add_related_object(&*arrival.stop),
                 )
             // Some timetable are rounded to the minute. For short distances this can result in a null duration
             // If stops are more than 500m appart, they should need at least a minute
@@ -65,7 +69,7 @@ fn validate_speeds(
             } else if duration > 0.0 && distance / duration > max_speed(route.route_type) {
                 result.push(
                     Issue::new_with_obj(
-                        Severity::Warning,
+                        Severity::Information,
                         IssueType::ExcessiveSpeed,
                         &*departure.stop,
                     )
@@ -84,7 +88,7 @@ fn validate_speeds(
                 )
             } else if distance / duration < 0.1 {
                 result.push(
-                    Issue::new_with_obj(Severity::Warning, IssueType::Slow, &*departure.stop)
+                    Issue::new_with_obj(Severity::Information, IssueType::Slow, &*departure.stop)
                         .add_related_object(&*arrival.stop)
                         .add_related_object(trip),
                 )

--- a/src/validators/issues.rs
+++ b/src/validators/issues.rs
@@ -11,7 +11,6 @@ pub enum Severity {
     Error,
     /// Not a specification error, but something is most likely wrong in the data.
     Warning,
-    #[allow(dead_code)]
     /// Simple information.
     Information,
 }

--- a/src/validators/shapes.rs
+++ b/src/validators/shapes.rs
@@ -6,7 +6,7 @@ pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
         .iter()
         .filter(|(_id, shapes)| !shapes.iter().all(has_coord))
         .map(|(id, _shapes)| {
-            Issue::new(Severity::Error, IssueType::MissingCoordinates, id)
+            Issue::new(Severity::Warning, IssueType::MissingCoordinates, id)
                 .object_type(gtfs_structures::ObjectType::Shape)
         });
     let valid = gtfs

--- a/src/validators/unused_stop.rs
+++ b/src/validators/unused_stop.rs
@@ -30,7 +30,7 @@ pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
 fn make_unused_stop_issue<T: gtfs_structures::Id + gtfs_structures::Type + std::fmt::Display>(
     o: &T,
 ) -> Issue {
-    Issue::new_with_obj(Severity::Error, IssueType::UnusedStop, o)
+    Issue::new_with_obj(Severity::Information, IssueType::UnusedStop, o)
 }
 
 #[test]


### PR DESCRIPTION
pass on all issue to check if the severity is relevant.

change the folowing severities:

object has empty name: Error -> Warning
coord 0/0: Error -> Warning
duplicate stop: Error -> Information
stop too close: Warning -> Information
coord 0/0 in shape: Error -> Warning
unused stop: Error -> Information