### PR TITLE
New fields on metadatas

### DIFF
--- a/src/metadatas.rs
+++ b/src/metadatas.rs
@@ -14,7 +14,7 @@ pub struct Metadata {
     pub modes: Vec<String>,
     pub issues_count: std::collections::BTreeMap<IssueType, usize>,
     pub has_fares: bool,
-    pub has_shapes: bool
+    pub has_shapes: bool,
 }
 
 pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
@@ -91,7 +91,8 @@ pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
 
 #[test]
 fn test_has_fares() {
-    let raw_gtfs = gtfs_structures::RawGtfs::new("test_data/fare_attributes").expect("Failed to load data");
+    let raw_gtfs =
+        gtfs_structures::RawGtfs::new("test_data/fare_attributes").expect("Failed to load data");
     let metadatas = extract_metadata(&raw_gtfs);
     assert_eq!(true, metadatas.has_fares);
 }
@@ -105,7 +106,8 @@ fn test_has_shapes() {
 
 #[test]
 fn test_no_fares_no_shapes() {
-    let raw_gtfs = gtfs_structures::RawGtfs::new("test_data/no_fares_no_shapes").expect("Failed to load data");
+    let raw_gtfs =
+        gtfs_structures::RawGtfs::new("test_data/no_fares_no_shapes").expect("Failed to load data");
     let metadatas = extract_metadata(&raw_gtfs);
     assert_eq!(false, metadatas.has_fares);
     assert_eq!(false, metadatas.has_shapes);

--- a/src/metadatas.rs
+++ b/src/metadatas.rs
@@ -85,11 +85,11 @@ pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
             .collect(),
         issues_count: std::collections::BTreeMap::new(),
         has_fares: match &gtfs.fare_attributes {
-            Some(Ok(fa)) => fa.len() > 0,
+            Some(Ok(fa)) => !fa.is_empty(),
             _ => false,
         },
         has_shapes: match &gtfs.shapes {
-            Some(Ok(s)) => s.len() > 0,
+            Some(Ok(s)) => !s.is_empty(),
             _ => false,
         },
     }

--- a/src/metadatas.rs
+++ b/src/metadatas.rs
@@ -88,3 +88,25 @@ pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
         has_shapes: gtfs.shapes.is_some(),
     }
 }
+
+#[test]
+fn test_has_fares() {
+    let raw_gtfs = gtfs_structures::RawGtfs::new("test_data/fare_attributes").expect("Failed to load data");
+    let metadatas = extract_metadata(&raw_gtfs);
+    assert_eq!(true, metadatas.has_fares);
+}
+
+#[test]
+fn test_has_shapes() {
+    let raw_gtfs = gtfs_structures::RawGtfs::new("test_data/shapes").expect("Failed to load data");
+    let metadatas = extract_metadata(&raw_gtfs);
+    assert_eq!(true, metadatas.has_shapes);
+}
+
+#[test]
+fn test_no_fares_no_shapes() {
+    let raw_gtfs = gtfs_structures::RawGtfs::new("test_data/no_fares_no_shapes").expect("Failed to load data");
+    let metadatas = extract_metadata(&raw_gtfs);
+    assert_eq!(false, metadatas.has_fares);
+    assert_eq!(false, metadatas.has_shapes);
+}

--- a/src/metadatas.rs
+++ b/src/metadatas.rs
@@ -13,6 +13,8 @@ pub struct Metadata {
     pub networks: Vec<String>,
     pub modes: Vec<String>,
     pub issues_count: std::collections::BTreeMap<IssueType, usize>,
+    pub has_fares: bool,
+    pub has_shapes: bool
 }
 
 pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
@@ -82,5 +84,7 @@ pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
             .unique()
             .collect(),
         issues_count: std::collections::BTreeMap::new(),
+        has_fares: gtfs.fare_attributes.is_some(),
+        has_shapes: gtfs.shapes.is_some(),
     }
 }

--- a/src/metadatas.rs
+++ b/src/metadatas.rs
@@ -84,8 +84,14 @@ pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
             .unique()
             .collect(),
         issues_count: std::collections::BTreeMap::new(),
-        has_fares: gtfs.fare_attributes.is_some(),
-        has_shapes: gtfs.shapes.is_some(),
+        has_fares: match &gtfs.fare_attributes {
+            Some(Ok(fa)) => fa.len() > 0,
+            _ => false,
+        },
+        has_shapes: match &gtfs.shapes {
+            Some(Ok(s)) => s.len() > 0,
+            _ => false,
+        },
     }
 }
 
@@ -94,14 +100,14 @@ fn test_has_fares() {
     let raw_gtfs =
         gtfs_structures::RawGtfs::new("test_data/fare_attributes").expect("Failed to load data");
     let metadatas = extract_metadata(&raw_gtfs);
-    assert_eq!(true, metadatas.has_fares);
+    assert!(metadatas.has_fares);
 }
 
 #[test]
 fn test_has_shapes() {
     let raw_gtfs = gtfs_structures::RawGtfs::new("test_data/shapes").expect("Failed to load data");
     let metadatas = extract_metadata(&raw_gtfs);
-    assert_eq!(true, metadatas.has_shapes);
+    assert!(metadatas.has_shapes);
 }
 
 #[test]
@@ -109,6 +115,6 @@ fn test_no_fares_no_shapes() {
     let raw_gtfs =
         gtfs_structures::RawGtfs::new("test_data/no_fares_no_shapes").expect("Failed to load data");
     let metadatas = extract_metadata(&raw_gtfs);
-    assert_eq!(false, metadatas.has_fares);
-    assert_eq!(false, metadatas.has_shapes);
+    assert!(!metadatas.has_fares);
+    assert!(!metadatas.has_shapes);
 }

--- a/test_data/no_fares_no_shapes/agency.txt
+++ b/test_data/no_fares_no_shapes/agency.txt
@@ -1,0 +1,3 @@
+agency_id,agency_name,agency_url,agency_timezone,agency_lang
+1,"BIBUS",http://www.bibus.fr,Europe/Paris,fr
+2,"Ter",http://www.sncf.com,Europe/Paris,fr

--- a/test_data/no_fares_no_shapes/calendar.txt
+++ b/test_data/no_fares_no_shapes/calendar.txt
@@ -1,0 +1,2 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+service1,0,0,0,0,0,1,1,20170101,20170115

--- a/test_data/no_fares_no_shapes/calendar_dates.txt
+++ b/test_data/no_fares_no_shapes/calendar_dates.txt
@@ -1,0 +1,4 @@
+service_id,date,exception_type
+service1,20170101,2
+service1,20170102,2
+service2,20170101,1

--- a/test_data/no_fares_no_shapes/fare_attributes.txt
+++ b/test_data/no_fares_no_shapes/fare_attributes.txt
@@ -1,0 +1,1 @@
+fare_id,price,currency_type,payment_method,transfers,agency_id,transfer_duration

--- a/test_data/no_fares_no_shapes/routes.txt
+++ b/test_data/no_fares_no_shapes/routes.txt
@@ -1,0 +1,3 @@
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
+1,848,"100","100","",3,,000000,FFFFFF
+invalid_type,848,"100","100","",42,,000000,FFFFFF

--- a/test_data/no_fares_no_shapes/stop_times.txt
+++ b/test_data/no_fares_no_shapes/stop_times.txt
@@ -1,0 +1,3 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_time_desc,pickup_type,drop_off_type
+trip1,14:00:00,14:00:00,stop2,0,"",0,1
+trip1,15:00:00,15:00:00,stop3,0,"",2,

--- a/test_data/no_fares_no_shapes/stops.txt
+++ b/test_data/no_fares_no_shapes/stops.txt
@@ -1,0 +1,6 @@
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,wheelchair_boarding
+stop1,"Stop Area",, 48.796058 ,2.449386,,,1,,
+stop2,"StopPoint",,48.796058,2.449386,,,,,
+stop3,"Stop Point child of 1",,48.796058,2.449386,,,0,1,
+stop4,"StopPoint2",,48.796058,2.449386,,,,,
+stop5,"Stop Point child of 1 bis",,48.796058,2.449386,,,0,1,

--- a/test_data/no_fares_no_shapes/trips.txt
+++ b/test_data/no_fares_no_shapes/trips.txt
@@ -1,0 +1,2 @@
+route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,wheelchair_accessible,bikes_allowed,trip_desc,shape_id
+route1,service1,trip1,"85088452",,0,,0,0,,


### PR DESCRIPTION
closes #94 

Adds 2 fields on metadatas : has_fares and has_shapes.

Only checks if the corresponding files exist, not if they contain something.