### PR TITLE
Add metadatas for stops needing a phone call to book a trip

### DIFF
--- a/src/metadatas.rs
+++ b/src/metadatas.rs
@@ -22,7 +22,7 @@ pub struct Metadata {
 }
 
 pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
-    use gtfs_structures::PickupDropOffType::*;
+    use gtfs_structures::PickupDropOffType;
     use gtfs_structures::RouteType::*;
 
     let start_end = gtfs
@@ -106,13 +106,13 @@ pub fn extract_metadata(gtfs: &gtfs_structures::RawGtfs) -> Metadata {
             .as_ref()
             .unwrap_or(&vec![])
             .iter()
-            .any(|st| has_on_demand_pickup_dropoff(st, ArrangeByPhone)),
+            .any(|st| has_on_demand_pickup_dropoff(st, PickupDropOffType::ArrangeByPhone)),
         some_stops_need_phone_driver: gtfs
             .stop_times
             .as_ref()
             .unwrap_or(&vec![])
             .iter()
-            .any(|st| has_on_demand_pickup_dropoff(st, CoordinateWithDriver)),
+            .any(|st| has_on_demand_pickup_dropoff(st, PickupDropOffType::CoordinateWithDriver)),
     }
 }
 

--- a/test_data/arrange_by_phone_stops/agency.txt
+++ b/test_data/arrange_by_phone_stops/agency.txt
@@ -1,0 +1,3 @@
+agency_id,agency_name,agency_url,agency_timezone,agency_lang
+1,"BIBUS",http://www.bibus.fr,Europe/Paris,fr
+2,"Ter",http://www.sncf.com,Europe/Paris,fr

--- a/test_data/arrange_by_phone_stops/calendar.txt
+++ b/test_data/arrange_by_phone_stops/calendar.txt
@@ -1,0 +1,2 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+service1,0,0,0,0,0,1,1,20170101,20170115

--- a/test_data/arrange_by_phone_stops/calendar_dates.txt
+++ b/test_data/arrange_by_phone_stops/calendar_dates.txt
@@ -1,0 +1,4 @@
+service_id,date,exception_type
+service1,20170101,2
+service1,20170102,2
+service2,20170101,1

--- a/test_data/arrange_by_phone_stops/fare_attributes.txt
+++ b/test_data/arrange_by_phone_stops/fare_attributes.txt
@@ -1,0 +1,3 @@
+fare_id,price,currency_type,payment_method,transfers,agency_id,transfer_duration
+50,,EUR,0,,1,3600
+61,1.50,ABC,1,3,2,

--- a/test_data/arrange_by_phone_stops/routes.txt
+++ b/test_data/arrange_by_phone_stops/routes.txt
@@ -1,0 +1,3 @@
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
+1,848,"100","100","",3,,000000,FFFFFF
+invalid_type,848,"100","100","",42,,000000,FFFFFF

--- a/test_data/arrange_by_phone_stops/shapes.txt
+++ b/test_data/arrange_by_phone_stops/shapes.txt
@@ -1,0 +1,4 @@
+shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled
+A_shp,37.61956,-122.48161,0,0
+A_shp,37.64430,-122.41070,6,6.8310
+A_shp,37.65863,-122.30839,11,15.8765

--- a/test_data/arrange_by_phone_stops/stop_times.txt
+++ b/test_data/arrange_by_phone_stops/stop_times.txt
@@ -1,0 +1,3 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_time_desc,pickup_type,drop_off_type
+trip1,14:00:00,14:00:00,stop2,0,"",0,0
+trip1,15:00:00,15:00:00,stop3,0,"",2,0

--- a/test_data/arrange_by_phone_stops/stops.txt
+++ b/test_data/arrange_by_phone_stops/stops.txt
@@ -1,0 +1,6 @@
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,wheelchair_boarding
+stop1,"Stop Area",, 48.796058 ,2.449386,,,1,,
+stop2,"StopPoint",,48.796058,2.449386,,,,,
+stop3,"Stop Point child of 1",,48.796058,2.449386,,,0,1,
+stop4,"StopPoint2",,48.796058,2.449386,,,,,
+stop5,"Stop Point child of 1 bis",,48.796058,2.449386,,,0,1,

--- a/test_data/arrange_by_phone_stops/trips.txt
+++ b/test_data/arrange_by_phone_stops/trips.txt
@@ -1,0 +1,2 @@
+route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,wheelchair_accessible,bikes_allowed,trip_desc,shape_id
+route1,service1,trip1,"85088452",,0,,0,0,,

--- a/test_data/coordinate_with_driver_stops/agency.txt
+++ b/test_data/coordinate_with_driver_stops/agency.txt
@@ -1,0 +1,3 @@
+agency_id,agency_name,agency_url,agency_timezone,agency_lang
+1,"BIBUS",http://www.bibus.fr,Europe/Paris,fr
+2,"Ter",http://www.sncf.com,Europe/Paris,fr

--- a/test_data/coordinate_with_driver_stops/calendar.txt
+++ b/test_data/coordinate_with_driver_stops/calendar.txt
@@ -1,0 +1,2 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+service1,0,0,0,0,0,1,1,20170101,20170115

--- a/test_data/coordinate_with_driver_stops/calendar_dates.txt
+++ b/test_data/coordinate_with_driver_stops/calendar_dates.txt
@@ -1,0 +1,4 @@
+service_id,date,exception_type
+service1,20170101,2
+service1,20170102,2
+service2,20170101,1

--- a/test_data/coordinate_with_driver_stops/fare_attributes.txt
+++ b/test_data/coordinate_with_driver_stops/fare_attributes.txt
@@ -1,0 +1,3 @@
+fare_id,price,currency_type,payment_method,transfers,agency_id,transfer_duration
+50,,EUR,0,,1,3600
+61,1.50,ABC,1,3,2,

--- a/test_data/coordinate_with_driver_stops/routes.txt
+++ b/test_data/coordinate_with_driver_stops/routes.txt
@@ -1,0 +1,3 @@
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
+1,848,"100","100","",3,,000000,FFFFFF
+invalid_type,848,"100","100","",42,,000000,FFFFFF

--- a/test_data/coordinate_with_driver_stops/shapes.txt
+++ b/test_data/coordinate_with_driver_stops/shapes.txt
@@ -1,0 +1,4 @@
+shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled
+A_shp,37.61956,-122.48161,0,0
+A_shp,37.64430,-122.41070,6,6.8310
+A_shp,37.65863,-122.30839,11,15.8765

--- a/test_data/coordinate_with_driver_stops/stop_times.txt
+++ b/test_data/coordinate_with_driver_stops/stop_times.txt
@@ -1,0 +1,3 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_time_desc,pickup_type,drop_off_type
+trip1,14:00:00,14:00:00,stop2,0,"",0,3
+trip1,15:00:00,15:00:00,stop3,0,"",0,0

--- a/test_data/coordinate_with_driver_stops/stops.txt
+++ b/test_data/coordinate_with_driver_stops/stops.txt
@@ -1,0 +1,6 @@
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,wheelchair_boarding
+stop1,"Stop Area",, 48.796058 ,2.449386,,,1,,
+stop2,"StopPoint",,48.796058,2.449386,,,,,
+stop3,"Stop Point child of 1",,48.796058,2.449386,,,0,1,
+stop4,"StopPoint2",,48.796058,2.449386,,,,,
+stop5,"Stop Point child of 1 bis",,48.796058,2.449386,,,0,1,

--- a/test_data/coordinate_with_driver_stops/trips.txt
+++ b/test_data/coordinate_with_driver_stops/trips.txt
@@ -1,0 +1,2 @@
+route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,wheelchair_accessible,bikes_allowed,trip_desc,shape_id
+route1,service1,trip1,"85088452",,0,,0,0,,


### PR DESCRIPTION
I added two fields in the metadatas :
- some_stops_need_phone_agency corresponding to pickup_type or drop_off_type == 2
- some_stops_need_phone_driver corresponding to pickup_type or drop_off_type == 3

closes #102 