### PR TITLE
Replace Trip references in related_objects by Routes (deduped)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-.vscode/launch.json

--- a/src/validators/duration_distance.rs
+++ b/src/validators/duration_distance.rs
@@ -126,8 +126,13 @@ fn validate_speeds(gtfs: &gtfs_structures::Gtfs) -> Result<Vec<Issue>, gtfs_stru
                             .add_related_object(&*arrival.stop)
                             .details(&details)
                     });
-                    // crappy implementation of "only add route if not already there"
-                    // if the idea is good, we'll likely switch to some hash map
+
+                    // In the past, we added each individual "trip" here, but it led to overly large
+                    // payloads due to the cardinality of trips (https://github.com/etalab/transport-validator/issues/101).
+                    // We now just refer to the corresponding route, and make sure the route is only added once.
+                    //
+                    // Because the number of routes is usually low on tested datasets, we just search if the route is already
+                    // there. Alternatively we could move to using a "set" here to optimize search time, if needed.
                     if !issue.related_objects.iter().any(|i| {
                         (i.id == route.id)
                             && (i.object_type.as_ref().unwrap()

--- a/src/validators/duration_distance.rs
+++ b/src/validators/duration_distance.rs
@@ -200,6 +200,7 @@ fn test_optimisation_route_trips() {
     let mut issues = validate(&gtfs);
 
     assert_eq!(1, issues.len());
+    // irrelevant to the test, but this acts as a guard in case someone modifies the fixtures
     assert_eq!(IssueType::CloseStops, issues[0].issue_type);
 
     // the routes order (for objects with index 1 and 2) is apparently non deterministic, for some

--- a/src/validators/duration_distance.rs
+++ b/src/validators/duration_distance.rs
@@ -189,3 +189,31 @@ fn test() {
     assert_eq!(String::from("null"), issues[4].related_objects[0].id);
     assert_eq!(Some(String::from("Near1")), issues[4].object_name);
 }
+
+#[test]
+fn test_optimisation_route_trips() {
+    let gtfs = gtfs_structures::Gtfs::new("test_data/optimisation_route_trips").unwrap();
+    let issues = validate(&gtfs);
+
+    assert_eq!(1, issues.len());
+    assert_eq!(IssueType::CloseStops, issues[0].issue_type);
+
+    assert_eq!(3, issues[0].related_objects.len());
+    assert_eq!(
+        issues[0].related_objects[0].object_type,
+        Some(gtfs_structures::ObjectType::Stop)
+    );
+    // we would normally refer to N trips here, but we optimised the payload by
+    // referring only to the parent route, and making sure the route appears only once.
+    assert_eq!(String::from("route1"), issues[0].related_objects[1].id);
+    assert_eq!(
+        issues[0].related_objects[1].object_type,
+        Some(gtfs_structures::ObjectType::Route)
+    );
+    // if multiple routes are involved, each will appear once
+    assert_eq!(String::from("route2"), issues[0].related_objects[2].id);
+    assert_eq!(
+        issues[0].related_objects[2].object_type,
+        Some(gtfs_structures::ObjectType::Route)
+    );
+}

--- a/src/validators/duration_distance.rs
+++ b/src/validators/duration_distance.rs
@@ -197,27 +197,20 @@ fn test() {
 #[test]
 fn test_optimisation_route_trips() {
     let gtfs = gtfs_structures::Gtfs::new("test_data/optimisation_route_trips").unwrap();
-    let issues = validate(&gtfs);
+    let mut issues = validate(&gtfs);
 
     assert_eq!(1, issues.len());
     assert_eq!(IssueType::CloseStops, issues[0].issue_type);
 
+    // the routes order (for objects with index 1 and 2) is apparently non deterministic, for some
+    // reason, so we sort the array to get a stable order and avoid random test failures
+    issues[0].related_objects.sort_by(|a, b| a.id.cmp(&b.id));
+
     assert_eq!(3, issues[0].related_objects.len());
-    assert_eq!(
-        issues[0].related_objects[0].object_type,
-        Some(gtfs_structures::ObjectType::Stop)
-    );
-    // we would normally refer to N trips here, but we optimised the payload by
-    // referring only to the parent route, and making sure the route appears only once.
-    assert_eq!(String::from("route1"), issues[0].related_objects[1].id);
-    assert_eq!(
-        issues[0].related_objects[1].object_type,
-        Some(gtfs_structures::ObjectType::Route)
-    );
-    // if multiple routes are involved, each will appear once
-    assert_eq!(String::from("route2"), issues[0].related_objects[2].id);
-    assert_eq!(
-        issues[0].related_objects[2].object_type,
-        Some(gtfs_structures::ObjectType::Route)
-    );
+
+    // we would normally find N trips here, but we optimised the payload by
+    // referring only to the parent route, and making sure each route appears only once.
+    assert_eq!("route1", issues[0].related_objects[0].id);
+    assert_eq!("route2", issues[0].related_objects[1].id);
+    assert_eq!("stop002", issues[0].related_objects[2].id);
 }

--- a/src/validators/duration_distance.rs
+++ b/src/validators/duration_distance.rs
@@ -126,7 +126,15 @@ fn validate_speeds(gtfs: &gtfs_structures::Gtfs) -> Result<Vec<Issue>, gtfs_stru
                             .add_related_object(&*arrival.stop)
                             .details(&details)
                     });
-                    issue.push_related_object(trip);
+                    // crappy implementation of "only add route if not already there"
+                    // if the idea is good, we'll likely switch to some hash map
+                    if !issue.related_objects.iter().any(|i| {
+                        (i.id == route.id)
+                            && (i.object_type.as_ref().unwrap()
+                                == &gtfs_structures::ObjectType::Route)
+                    }) {
+                        issue.push_related_object(route);
+                    }
                 }
             }
         }

--- a/src/validators/duration_distance.rs
+++ b/src/validators/duration_distance.rs
@@ -135,8 +135,7 @@ fn validate_speeds(gtfs: &gtfs_structures::Gtfs) -> Result<Vec<Issue>, gtfs_stru
                     // there. Alternatively we could move to using a "set" here to optimize search time, if needed.
                     if !issue.related_objects.iter().any(|i| {
                         (i.id == route.id)
-                            && (i.object_type.as_ref().unwrap()
-                                == &gtfs_structures::ObjectType::Route)
+                            && (i.object_type == Some(gtfs_structures::ObjectType::Route))
                     }) {
                         issue.push_related_object(route);
                     }

--- a/test_data/optimisation_route_trips/agency.txt
+++ b/test_data/optimisation_route_trips/agency.txt
@@ -1,0 +1,1 @@
+agency_id,agency_name,agency_url,agency_timezone,agency_lang

--- a/test_data/optimisation_route_trips/calendar.txt
+++ b/test_data/optimisation_route_trips/calendar.txt
@@ -1,0 +1,1 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date

--- a/test_data/optimisation_route_trips/routes.txt
+++ b/test_data/optimisation_route_trips/routes.txt
@@ -1,0 +1,3 @@
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
+route1,848,"100","100","",3,,000000,FFFFFF
+route2,848,"100","100","",3,,000000,FFFFFF

--- a/test_data/optimisation_route_trips/stop_times.txt
+++ b/test_data/optimisation_route_trips/stop_times.txt
@@ -1,0 +1,9 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_time_desc,pickup_type,drop_off_type
+trip001,14:00:00,14:00:00,stop001,0,"",0,0
+trip001,14:01:00,14:01:00,stop002,0,"",0,0
+trip002,14:00:00,14:00:00,stop001,0,"",0,0
+trip002,14:01:00,14:01:00,stop002,0,"",0,0
+trip003,14:00:00,14:00:00,stop001,0,"",0,0
+trip003,14:01:00,14:01:00,stop002,0,"",0,0
+trip004,14:00:00,14:00:00,stop001,0,"",0,0
+trip004,14:01:00,14:01:00,stop002,0,"",0,0

--- a/test_data/optimisation_route_trips/stops.txt
+++ b/test_data/optimisation_route_trips/stops.txt
@@ -1,0 +1,3 @@
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,wheelchair_boarding
+stop001,"Close 1",,48.796058,2.449386,,,,,
+stop002,"Close 2",,48.796058,2.449385,,,,,

--- a/test_data/optimisation_route_trips/trips.txt
+++ b/test_data/optimisation_route_trips/trips.txt
@@ -1,0 +1,5 @@
+route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,wheelchair_accessible,bikes_allowed,trip_desc,shape_id
+route1,,trip001,"85088452",,0,,0,0,,
+route1,,trip002,"85088452",,0,,0,0,,
+route1,,trip003,"85088452",,0,,0,0,,
+route2,,trip004,"85088452",,0,,0,0,,


### PR DESCRIPTION
Related to #101.

This is a work-in-progress which will be discussed; creating this to save some logs & notes.

I have no idea if the optimisation is functionally correct at this point 😄

## TODOS

- [x] Verify the approach validity with teammates (or replace with something else)
- [x] ~~(?) add number of trips (as mentioned in #101) somewhere as meta-data ?~~ - EDIT: we'll keep that for later
- [x] Implement just 1 test as an exercise
- [x] Make sure the tests are deterministic (order of related objects seems a bit random sometimes)
- [x] Run the validator via the Elixir app to verify the PR doesn't break the visual representation of the validations

## Ideas pursued

* Refer to a single route instead of N trips (will this impact the rendering of validations on the transport site ???)
* Already discussed but not pursued yet: trim the number of issues by type ?

```
"issues_count": {
      "Slow": 8,
      "ExcessiveSpeed": 332,
      "NegativeTravelTime": 6,
      "CloseStops": 2452,
      "NullDuration": 236,
      "MissingCoordinates": 57,
      "InvalidUrl": 2,
      "DuplicateStops": 4679
    },
```

## Notes

The first implementation did not break any test, which means that the test coverage doesn't cover the related objects parts completely.

## Payload size comparison

Payload is roughly 14x smaller on largest file:

```
-rw-r--r--   1 thbar  staff  13331527 Dec 14 11:29 12_2020_mobibreizhbret_gtfs.master.json
-rw-r--r--   1 thbar  staff    940124 Dec 14 11:39 12_2020_mobibreizhbret_gtfs.reduce.json
```

## Example of change in a specific object

The output order is a bit random + trimmed to 1000 items, so we have to search a bit to find corresponding issue id in the two files (before/after). This helped me:

```
cat XYZ | jq '.validations.CloseStops[].object_id' | sort
```

This helps find a few identical ids, which can then be compared:

```
cat $1 | jq '.validations.CloseStops[] | select(.object_id=="TUB:21304")'
```

Before:

```json
{
  "severity": "Information",
  "issue_type": "CloseStops",
  "object_id": "TUB:21304",
  "object_type": "Stop",
  "object_name": "Gare Centre",
  "related_objects": [
    {
      "id": "TUB:21304",
      "object_type": "Stop",
      "name": "Gare Centre"
    },
    {
      "id": "TUB:218090:644",
      "object_type": "Trip",
      "name": "route id: TUB:8, service id: REGEN_232"
    },
    {
      "id": "TUB:218012:644",
      "object_type": "Trip",
      "name": "route id: TUB:8, service id: REGEN_220"
    },
    {
      "id": "TUB:218117:644",
      "object_type": "Trip",
      "name": "route id: TUB:8, service id: REGEN_232"
    },
    {
      "id": "TUB:216707:644",
      "object_type": "Trip",
      "name": "route id: TUB:6, service id: REGEN_220"
    },
    {
      "id": "TUB:135590:644",
      "object_type": "Trip",
      "name": "route id: TUB:63, service id: REGEN_218"
    },
    {
      "id": "TUB:216690:644",
      "object_type": "Trip",
      "name": "route id: TUB:6, service id: REGEN_220"
    },
# SNIP (lots of data)
    {
      "id": "TUB:218003:644",
      "object_type": "Trip",
      "name": "route id: TUB:8, service id: REGEN_220"
    }
  ],
  "details": "distance between the stops is 0 meter(s)"
}
```

After:

```json
{
  "severity": "Information",
  "issue_type": "CloseStops",
  "object_id": "TUB:21304",
  "object_type": "Stop",
  "object_name": "Gare Centre",
  "related_objects": [
    {
      "id": "TUB:21304",
      "object_type": "Stop",
      "name": "Gare Centre"
    },
    {
      "id": "TUB:6",
      "object_type": "Route",
      "name": "Cesson Bourg - Les Villages Espace Commercial"
    },
    {
      "id": "TUB:8",
      "object_type": "Route",
      "name": "Ville Oger - Collège Léquier"
    },
    {
      "id": "TUB:78",
      "object_type": "Route",
      "name": "Plérin Eglise  - Trégueux  Bleu Pluriel"
    },
    {
      "id": "TUB:69",
      "object_type": "Route",
      "name": "Ploufragan - Trégueux"
    },
    {
      "id": "TUB:63",
      "object_type": "Route",
      "name": "Les Villages - Cesson  République"
    },
    {
      "id": "TUB:64",
      "object_type": "Route",
      "name": "Langueux Poste - Ploufragan Lorraine"
    }
  ],
  "details": "distance between the stops is 0 meter(s)"
}
```

## Runtime duration

### Duration comparison on large file

Duration looks very similar, so at least I haven't killed performance:

On `master` (6a5e5aa):

```
cargo build --release
time cargo run --release -- --input ../gtfs-data/12_2020_mobibreizhbret_gtfs.zip > ../gtfs-data/12_2020_mobibreizhbret_gtfs.master.json
real	0m10.626s
```

### After optimisation

On branch (b01bebb2):

```
$ time cargo run --release -- --input ../gtfs-data/12_2020_mobibreizhbret_gtfs.zip > ../gtfs-data/12_2020_mobibreizhbret_gtfs.reduce.json
    Finished release [optimized] target(s) in 0.42s
     Running `target/release/main --input ../gtfs-data/12_2020_mobibreizhbret_gtfs.zip`
[2020-12-14T10:39:12Z INFO  validator::validate] Starting validation: ../gtfs-data/12_2020_mobibreizhbret_gtfs.zip

real	0m10.820s
```