### PR TITLE
change impossible interpolation severity

### DIFF
--- a/src/validators/interpolated_stoptimes.rs
+++ b/src/validators/interpolated_stoptimes.rs
@@ -21,7 +21,7 @@ fn impossible_to_interpolate_st(trip: &gtfs_structures::Trip) -> Option<Issue> {
         {
             Some(
                 Issue::new_with_obj(
-                    Severity::Warning,
+                    Severity::Error,
                     IssueType::ImpossibleToInterpolateStopTimes,
                     trip,
                 )


### PR DESCRIPTION
Since it will be impossible for several tools to work on the GTFS, change the severity of the `ImpossibleToInterpolateStopTimes` error from warning to error