### PR TITLE
Add allowed optional files

### DIFF
--- a/src/validators/file_presence.rs
+++ b/src/validators/file_presence.rs
@@ -17,6 +17,11 @@ const OPTIONAL_FILES: &[&str] = &[
     "frequencies.txt",
     "transfers.txt",
     "shapes.txt",
+    "pathways.txt",
+    "levels.txt",
+    "feed_info.txt",
+    "translations.txt",
+    "attributions.txt",
 ];
 
 fn missing_files(raw_gtfs: &gtfs_structures::RawGtfs) -> Vec<Issue> {

--- a/test_data/missing_mandatory_files/attributions.txt
+++ b/test_data/missing_mandatory_files/attributions.txt
@@ -1,0 +1,1 @@
+I can exist

--- a/test_data/missing_mandatory_files/feed_info.txt
+++ b/test_data/missing_mandatory_files/feed_info.txt
@@ -1,0 +1,1 @@
+I can exist

--- a/test_data/missing_mandatory_files/levels.txt
+++ b/test_data/missing_mandatory_files/levels.txt
@@ -1,0 +1,1 @@
+I can exist

--- a/test_data/missing_mandatory_files/pathways.txt
+++ b/test_data/missing_mandatory_files/pathways.txt
@@ -1,0 +1,1 @@
+I can exist

--- a/test_data/missing_mandatory_files/translations.txt
+++ b/test_data/missing_mandatory_files/translations.txt
@@ -1,0 +1,1 @@
+I can exist


### PR DESCRIPTION
Some files have been to the spec as optional files. Their presence should not create any warning.

    "pathways.txt",
    "levels.txt",
    "feed_info.txt",
    "translations.txt",
    "attributions.txt",

See https://developers.google.com/transit/gtfs/reference#pathwaystxt