### PR TITLE
Officialize URL support for --input flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -284,7 +284,7 @@ You can then ask for a validation:
 
 ## Options
 
-* `--input` or `-i`: Path to the gtfs file. Can be a directory or a zip file
+* `--input` or `-i`: Path (can be a directory or a zip file) or HTTP URL (file will be downloaded) of the GTFS file.
 * `--max-issues` or `-m`: The maxium number of issues per type. Defaults to 1000.
 * `--output-format` or `-f`: Output format (when using the validator in command line). Value by default is `json`, but `yaml` is also available.
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -17,7 +17,7 @@ struct Opt {
     #[structopt(
         short = "i",
         long = "input",
-        help = "Path to the gtfs file. Can be a directory or a zip file"
+        help = "Path to the gtfs file (can be a directory or a zip file) or HTTP URL of the file (will be downloaded)"
     )]
     input: Option<String>,
     #[structopt(

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -23,7 +23,7 @@ struct Opt {
     #[structopt(
         short = "m",
         long = "max-issues",
-        help = "The maxium number of issues per type",
+        help = "The maximum number of issues per type",
         default_value = "1000"
     )]
     max_size: usize,


### PR DESCRIPTION
While using the validator, I remembered that I could pass the URL of a file instead of downloading it first, and that it didn't appear in the `--help` output.

This PR modifies the `--help` to show we support it.

### Verifications completed before doing the proposal

The command line `--input` flag is managed here:

https://github.com/etalab/transport-validator/blob/7dde612d0c860c40a8b639ec4c74403402df79d3/src/bin/main.rs#L16-L22

and then used here to start the validation:

https://github.com/etalab/transport-validator/blob/7dde612d0c860c40a8b639ec4c74403402df79d3/src/bin/main.rs#L44-L47

and downstream forwarded to the `gtfs-structures` crate:

https://github.com/etalab/transport-validator/blob/b16031a37235cc17b312c224e7f7d6465a804f53/src/validate.rs#L106-L108

Which doc states (https://docs.rs/gtfs-structures/0.32.2/gtfs_structures/struct.RawGtfs.html#method.new):

> Reads from an url (if starts with http), or a local path (either a directory or zipped file)

As a result so far it feels safe to add an official support in the validator itself (unless there are plans to deprecate this support in the `gtfs-structures` create