### PR TITLE
Shapes: fix has_coord condition

### DIFF
--- a/src/validators/shapes.rs
+++ b/src/validators/shapes.rs
@@ -69,7 +69,7 @@ fn create_invalid_shape_id_issue(
 }
 
 fn has_coord(shape: &gtfs_structures::Shape) -> bool {
-    shape.latitude != 0.0 && shape.longitude != 0.0
+    shape.latitude != 0.0 || shape.longitude != 0.0
 }
 
 fn valid_coord(shape: &gtfs_structures::Shape) -> bool {

--- a/test_data/shapes/shapes.txt
+++ b/test_data/shapes/shapes.txt
@@ -1,5 +1,5 @@
 shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled
-A_shp,0.0,-122.48161,0,0
+A_shp,0.0,-122.48161,42,0
 A_shp,97.64430,-122.41070,6,6.8310
 A_shp,37.65863,-122.30839,11,15.8765
 B_shp,37.64430,-122.41070,6,6.8310

--- a/test_data/shapes/shapes.txt
+++ b/test_data/shapes/shapes.txt
@@ -1,5 +1,5 @@
 shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled
-A_shp,0.0,-122.48161,42,0
+A_shp,0,0,0,0
 A_shp,97.64430,-122.41070,6,6.8310
 A_shp,37.65863,-122.30839,11,15.8765
 B_shp,37.64430,-122.41070,6,6.8310


### PR DESCRIPTION
The previous code raised an error when the latitude or the longitude was 0. It's fine for one of them to be 0, both 0 should be an error.