### PR TITLE
Update severities for URL rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,8 +120,6 @@ Here is a human friendly list of them :
 | MissingName | Warning | An agency, a route or a stop has its name missing. |
 | MissingCoordinates | Warning | A shape point or a stop is missing its coordinate(s). |
 | NullDuration | Warning | The travel duration between two stops is null. |
-| MissingUrl | Warning | An agency or a feed publisher is missing its URL. |
-| InvalidUrl | Warning | The URL of an agency or a feed publisher is not valid. |
 | MissingLanguage | Warning | The publisher language code is missing. |
 | InvalidLanguage | Warning | The publisher language code is not valid. |
 | DuplicateObjectId | Warning | The object has at least one object with the same id. |
@@ -130,6 +128,8 @@ Here is a human friendly list of them :
 | IdNotAscii | Warning | The identifier is not only ASCII characters |
 |  |  |  |
 | MissingId | Error | An agency, a calendar, a route, a shape point, a stop or a trip has its Id missing. |
+| MissingUrl | Error | An agency or a feed publisher is missing its URL. |
+| InvalidUrl | Error | The URL of an agency or a feed publisher is not valid. |
 | InvalidCoordinates | Error | The coordinates of a shape point or a stop are not valid. |
 | InvalidTimezone | Error | The TimeZone of an agency is not valid. |
 | MissingPrice | Error | A fare is missing its price. |

--- a/src/validators/agency.rs
+++ b/src/validators/agency.rs
@@ -5,13 +5,13 @@ pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
         .agencies
         .iter()
         .filter(|agency| !has_url(agency))
-        .map(|agency| Issue::new_with_obj(Severity::Warning, IssueType::MissingUrl, agency));
+        .map(|agency| Issue::new_with_obj(Severity::Error, IssueType::MissingUrl, agency));
     let invalid_url =
         gtfs.agencies
             .iter()
             .filter(|agency| has_url(agency) && !valid_url(agency))
             .map(|agency| {
-                Issue::new_with_obj(Severity::Warning, IssueType::InvalidUrl, agency).details(
+                Issue::new_with_obj(Severity::Error, IssueType::InvalidUrl, agency).details(
                     &format!("The agency_url (in agency.txt) {} is invalid", agency.url),
                 )
             });
@@ -28,8 +28,10 @@ fn has_url(agency: &gtfs_structures::Agency) -> bool {
 }
 
 fn valid_url(agency: &gtfs_structures::Agency) -> bool {
+    // https://gtfs.org/schedule/reference/#field-types
+    // URL - A fully qualified URL that includes http:// or https://
     match url::Url::parse(agency.url.as_ref()) {
-        Ok(url) => vec!["https", "http", "ftp"].contains(&url.scheme()),
+        Ok(url) => vec!["https", "http"].contains(&url.scheme()),
         _ => false,
     }
 }

--- a/src/validators/feed_info.rs
+++ b/src/validators/feed_info.rs
@@ -5,14 +5,14 @@ pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
         .feed_info
         .iter()
         .filter(is_missing_url)
-        .map(|feed_info| make_issue(feed_info, Severity::Warning, IssueType::MissingUrl));
+        .map(|feed_info| make_issue(feed_info, Severity::Error, IssueType::MissingUrl));
     let invalid_url = gtfs
         .feed_info
         .iter()
         .filter(|fi| !is_missing_url(fi) && is_invalid_url(fi))
         .map(|feed_info| {
-            make_issue(feed_info, Severity::Warning, IssueType::InvalidUrl).details(&format!(
-                "The feed_publisher_url (in feed_infos.txt) {} is invalid",
+            make_issue(feed_info, Severity::Error, IssueType::InvalidUrl).details(&format!(
+                "The feed_publisher_url (in feed_info.txt) {} is invalid",
                 feed_info.url
             ))
         });
@@ -45,8 +45,10 @@ fn is_missing_url(feed: &&gtfs_structures::FeedInfo) -> bool {
 }
 
 fn is_invalid_url(feed: &&gtfs_structures::FeedInfo) -> bool {
+    // https://gtfs.org/schedule/reference/#field-types
+    // URL - A fully qualified URL that includes http:// or https://
     !url::Url::parse(feed.url.as_ref())
-        .map(|url| vec!["https", "http", "ftp"].contains(&url.scheme()))
+        .map(|url| vec!["https", "http"].contains(&url.scheme()))
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
Fixes #170

- Update URL rules: `MissingUrl` and `InvalidUrl` from `Warning` to `Error` because the GTFS spec says that [these fields are required](https://gtfs.org/schedule/reference/#agencytxt).
- Remove FTP as a possible scheme, the spec does not list it.