### PR TITLE
Add a new rule to check the stop sequences of a trip

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ Here is a human friendly list of them :
 | CloseStops | Information | Two stops very close to each other in the same trips |
 | InvalidRouteType | Information | The type of a route is not valid. |
 | DuplicateStops | Information | Two stop points or stop areas look identical. They share the same name, and are geographically very close. This check is not applied to station entrances (`location_type` equal to `2`) |
-| DuplicateStopSequence | Error | Several stoptimes in a trip have the same stop_sequence. All the stop sequences should be uniq for a trip. |
+| DuplicateStopSequence | Error | Several stoptimes in a trip have the same stop_sequence. All the stop sequences should be unique for a trip. |
 | ExtraFile | Information | The file does not belong to a GTFS archive |
 | UnusedShapeId | Information | A shape_id defined in shapes.txt is not used elsewhere in the GTFS |
 |  |  |  |

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@ Here is a human friendly list of them :
 | CloseStops | Information | Two stops very close to each other in the same trips |
 | InvalidRouteType | Information | The type of a route is not valid. |
 | DuplicateStops | Information | Two stop points or stop areas look identical. They share the same name, and are geographically very close. This check is not applied to station entrances (`location_type` equal to `2`) |
+| DuplicateStopSequence | Error | Several stoptimes in a trip have the same stop_sequence. All the stop sequences should be uniq for a trip. |
 | ExtraFile | Information | The file does not belong to a GTFS archive |
 | UnusedShapeId | Information | A shape_id defined in shapes.txt is not used elsewhere in the GTFS |
 |  |  |  |

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ Here is a human friendly list of them :
 | CloseStops | Information | Two stops very close to each other in the same trips |
 | InvalidRouteType | Information | The type of a route is not valid. |
 | DuplicateStops | Information | Two stop points or stop areas look identical. They share the same name, and are geographically very close. This check is not applied to station entrances (`location_type` equal to `2`) |
-| DuplicateStopSequence | Error | Several stoptimes in a trip have the same stop_sequence. All the stop sequences should be unique for a trip. |
+| DuplicateStopSequence | Error | Several stop times in a trip have the same `stop_sequence` value. The stop_sequence values within a trip must be unique. |
 | ExtraFile | Information | The file does not belong to a GTFS archive |
 | UnusedShapeId | Information | A shape_id defined in shapes.txt is not used elsewhere in the GTFS |
 |  |  |  |

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -89,6 +89,8 @@ pub enum IssueType {
     InvalidShapeId,
     /// A shape id defined in shapes.txt is not used elsewhere
     UnusedShapeId,
+    /// Duplicate stop sequence in trip
+    DuplicateStopSequence,
 }
 
 /// Represents an object related to another object that is causing an issue.

--- a/src/validators/stop_times.rs
+++ b/src/validators/stop_times.rs
@@ -1,11 +1,19 @@
 use crate::issues::{Issue, IssueType, Severity};
 use gtfs_structures::LocationType;
+use itertools::Itertools;
 use std::collections::HashMap;
+use std::iter::once;
 
 /// To limit the size of the issue, we limit, by stops, the number of trip associated to a wrong stop
 const MAX_TRIPS: usize = 20;
 
 pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
+    check_location_type(gtfs)
+        .chain(check_valid_stop_sequence(gtfs))
+        .collect()
+}
+
+fn check_location_type(gtfs: &gtfs_structures::Gtfs) -> impl Iterator<Item = Issue> + '_ {
     let mut wrong_stops = HashMap::new();
     gtfs.trips.values().for_each(|trip| {
         trip.stop_times.iter().for_each(|st| {
@@ -30,11 +38,40 @@ pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
         })
     });
 
-    wrong_stops.into_iter().map(|(_, v)| v).collect()
+    wrong_stops.into_iter().map(|(_, v)| v)
+}
+
+// All stop_sequence of the stop times of a given trip should be different
+fn check_valid_stop_sequence(gtfs: &gtfs_structures::Gtfs) -> impl Iterator<Item = Issue> + '_ {
+    gtfs.trips.values().filter_map(|trip| {
+        let stop_with_same_sequence = trip
+            .stop_times
+            .iter()
+            .tuple_windows()
+            .filter_map(|(s1, s2)| {
+                if s1.stop_sequence == s2.stop_sequence {
+                    Some(once(s1).chain(once(s2)))
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+        if !stop_with_same_sequence.is_empty() {
+            let mut issue =
+                Issue::new_with_obj(Severity::Error, IssueType::DuplicateStopSequence, trip);
+            for st in stop_with_same_sequence {
+                issue.push_related_object(st.stop.as_ref());
+            }
+            Some(issue)
+        } else {
+            None
+        }
+    })
 }
 
 #[test]
-fn test() {
+fn test_location_type() {
     let gtfs = gtfs_structures::Gtfs::new("test_data/stop_times_location_type").unwrap();
     let issues = dbg!(validate(&gtfs));
 
@@ -47,4 +84,38 @@ fn test() {
     assert_eq!("STOP_AREA", first_issue.object_id);
     // 2 trips are linked to the stop 'STOP_AREA'
     assert_eq!(2, first_issue.related_objects.len());
+}
+
+#[test]
+fn test_stop_sequences() {
+    let gtfs = gtfs_structures::Gtfs::new("test_data/duplicate_stop_sequence").unwrap();
+    let mut issues = dbg!(validate(&gtfs));
+
+    assert_eq!(2, issues.len());
+
+    // 3 trips should be in error
+    issues.sort_by_key(|a| a.object_id.to_string());
+    let first_issue = &mut issues[0];
+    assert_eq!(IssueType::DuplicateStopSequence, first_issue.issue_type);
+    assert_eq!("trip2", first_issue.object_id);
+
+    // 2 trips are linked to the stop 'STOP_AREA'
+    first_issue.related_objects.sort_by_key(|ro| ro.id.clone());
+    assert_eq!(
+        vec![
+            crate::RelatedObject {
+                id: "stopB".to_string(),
+                name: Some("Stop B".to_string()),
+                object_type: Some(gtfs_structures::ObjectType::Stop)
+            },
+            crate::RelatedObject {
+                id: "stopC".to_string(),
+                name: Some("Stop C".to_string()),
+                object_type: Some(gtfs_structures::ObjectType::Stop)
+            },
+        ],
+        first_issue.related_objects
+    );
+    assert_eq!("trip3", &issues[1].object_id);
+    assert_eq!(2, issues[1].related_objects.len());
 }

--- a/src/validators/stop_times.rs
+++ b/src/validators/stop_times.rs
@@ -38,7 +38,7 @@ fn check_location_type(gtfs: &gtfs_structures::Gtfs) -> impl Iterator<Item = Iss
         })
     });
 
-    wrong_stops.into_iter().map(|(_, v)| v)
+    wrong_stops.into_values()
 }
 
 // All stop_sequence of the stop times of a given trip should be different
@@ -49,6 +49,8 @@ fn check_valid_stop_sequence(gtfs: &gtfs_structures::Gtfs) -> impl Iterator<Item
             .iter()
             .tuple_windows()
             .filter_map(|(s1, s2)| {
+                // All stoptimes are sorted by stopsequence (thus the importance of correct stop sequences)
+                // so we just need to check the next stoptime
                 if s1.stop_sequence == s2.stop_sequence {
                     Some(once(s1).chain(once(s2)))
                 } else {

--- a/test_data/duplicate_stop_sequence/agency.txt
+++ b/test_data/duplicate_stop_sequence/agency.txt
@@ -1,0 +1,3 @@
+agency_name,agency_url,agency_timezone,agency_lang
+"BIBUS",http://www.bibus.fr,Europe/Paris,fr
+"Ter",http://www.sncf.com,Europe/Paris,fr

--- a/test_data/duplicate_stop_sequence/calendar.txt
+++ b/test_data/duplicate_stop_sequence/calendar.txt
@@ -1,0 +1,2 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+service1,0,0,0,0,0,1,1,20170101,20170115

--- a/test_data/duplicate_stop_sequence/calendar_dates.txt
+++ b/test_data/duplicate_stop_sequence/calendar_dates.txt
@@ -1,0 +1,4 @@
+service_id,date,exception_type
+service1,20170101,2
+service1,20170102,2
+service2,20170101,1

--- a/test_data/duplicate_stop_sequence/routes.txt
+++ b/test_data/duplicate_stop_sequence/routes.txt
@@ -1,0 +1,2 @@
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
+route1,848,"100","100","",3,,000000,FFFFFF

--- a/test_data/duplicate_stop_sequence/stop_times.txt
+++ b/test_data/duplicate_stop_sequence/stop_times.txt
@@ -1,0 +1,8 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_time_desc,pickup_type,drop_off_type
+trip1,14:00:00,14:00:00,stopA,0,"",0,0
+trip1,15:00:00,15:00:00,stopB,10,"",0,0
+trip2,14:00:00,14:00:00,stopA,1,"",0,0
+trip2,15:00:00,15:00:00,stopB,10,"",0,0
+trip2,16:00:00,16:00:00,stopC,10,"",0,0
+trip3,14:00:00,14:00:00,stopA,0,"",0,0
+trip3,15:01:00,15:01:00,stopB,0,"",0,0

--- a/test_data/duplicate_stop_sequence/stops.txt
+++ b/test_data/duplicate_stop_sequence/stops.txt
@@ -1,0 +1,4 @@
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,wheelchair_boarding
+stopA,"Stop A",,48.796058,2.449386,,,,,
+stopB,"Stop B",,48.796058,2.449385,,,,,
+stopC,"Stop C",,48.796058,2.449186,,,,,

--- a/test_data/duplicate_stop_sequence/trips.txt
+++ b/test_data/duplicate_stop_sequence/trips.txt
@@ -1,0 +1,4 @@
+route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,wheelchair_accessible,bikes_allowed,trip_desc,shape_id
+route1,service1,trip1,"85088452",,0,,0,0,,
+route1,service1,trip2,"85088452",,0,,0,0,,
+route1,service1,trip3,"85088452",,0,,0,0,,


### PR DESCRIPTION
In the documentation the stop_sequences of a trip are the order of the stoptimes and they should all be different.

I got bited by a malformed test due to this, so this adds a new rule to check this.