### PR TITLE
make daemon support optional behind a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,19 @@ lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic
 
+[features]
+default = ["daemon"]
+daemon = ["actix-web", "actix-rt", "futures", "read-url", "env_logger"]
+read-url = ["gtfs-structures/read-url"]
+
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.8"
-env_logger = "0.10"
+env_logger = { version = "0.10", optional = true }
 anyhow = "1"
-futures = "0.3"
+futures = { version = "0.3", optional = true }
 geo = "0.27"
-gtfs-structures = "0.40"
+gtfs-structures = { version = "0.40", default-features = false }
 iso4217 = "0.3"
 isolang = "2.1"
 itertools = "0.12"
@@ -26,8 +31,8 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 structopt = "0.3"
 url = "2"
-actix-web = "4.0"
-actix-rt = "2"
+actix-web = { version = "4.0", optional = true }
+actix-rt = { version = "2", optional = true }
 geojson = "0.24"
 rgb = "0.8"
 

--- a/readme.md
+++ b/readme.md
@@ -317,6 +317,12 @@ cargo run --release -- -i some_gtfs.zip
 cargo run --release -- -i https://example.com/network.gfts
 ```
 
+If you do not intend to run the validator as a dæmon, it can be compiled without dæmon support, saving on compile time and binary size:
+
+```
+cargo run --release --no-default-features -- -i some_gtfs.zip
+```
+
 ### Run as a dæmon
 
 The validator can run as a HTTP dæmon to validate any file from a url.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,6 @@
-use validator::{custom_rules, daemon, validate};
+#[cfg(feature = "daemon")]
+use validator::daemon;
+use validator::{custom_rules, validate};
 
 use structopt::clap::arg_enum;
 use structopt::StructOpt;
@@ -45,6 +47,7 @@ struct Opt {
 }
 
 fn main() -> Result<(), anyhow::Error> {
+    #[cfg(feature = "daemon")]
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let opt = Opt::from_args();
@@ -59,8 +62,17 @@ fn main() -> Result<(), anyhow::Error> {
         };
         println!("{}", serialized);
     } else {
-        log::info!("Starting the validator as a dæmon");
-        daemon::run_server()?;
+        #[cfg(feature = "daemon")]
+        {
+            log::info!("Starting the validator as a dæmon");
+            daemon::run_server()?;
+        }
+        #[cfg(not(feature = "daemon"))]
+        {
+            eprintln!("transport-validator was compiled without support for running as daemon.");
+            eprintln!("use -i to supply a local file to test instead.");
+            std::process::exit(1);
+        }
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod custom_rules;
+#[cfg(feature = "daemon")]
 pub mod daemon;
 pub mod issues;
 pub mod metadatas;


### PR DESCRIPTION
This allows compiling the validator without support for the server/daemon mode by doing `cargo build --no-default-features` for users who don't intend to run the validator as a service but only want to check e.g. a few local files.

This greatly saves on compile times and binary size (as rough numbers: on my machine I end up with 141 MiB vs 47 MiB for debug builds with and without daemon mode, and 8 MiB vs 3.2 MiB for release builds. Compile times in release mode are less then half without daemon mode, from 1min 23s to just 27s).