### PR TITLE
MissingCoordinates: 0 is valid for latitude or longitude

### DIFF
--- a/src/metadatas.rs
+++ b/src/metadatas.rs
@@ -441,9 +441,9 @@ mod tests {
         assert_eq!(
             serde_json::to_string_pretty(&metadatas.stats).unwrap(),
             r#"{
-  "stops_count": 17,
+  "stops_count": 19,
   "stop_areas_count": 2,
-  "stop_points_count": 9,
+  "stop_points_count": 11,
   "stops_with_wheelchair_info_count": null,
   "routes_count": 5,
   "routes_with_custom_color_count": 0,
@@ -466,9 +466,9 @@ mod tests {
         assert_eq!(
             serde_json::to_string_pretty(&metadatas.stats).unwrap(),
             r#"{
-  "stops_count": 17,
+  "stops_count": 19,
   "stop_areas_count": 2,
-  "stop_points_count": 9,
+  "stop_points_count": 11,
   "stops_with_wheelchair_info_count": 0,
   "routes_count": 5,
   "routes_with_custom_color_count": 0,

--- a/src/validators/stops.rs
+++ b/src/validators/stops.rs
@@ -87,8 +87,6 @@ fn check_coord(stop: &gtfs_structures::Stop) -> Option<Issue> {
                 (Some(lon), Some(lat)) if lon == 0.0 && lat == 0.0 => {
                     "Latitude and longitude are missing"
                 }
-                (Some(lon), _) if lon == 0.0 => "Longitude is missing",
-                (_, Some(lat)) if lat == 0.0 => "Latitude is missing",
                 _ => "Coordinates are ok",
             }),
         )
@@ -99,7 +97,7 @@ fn check_coord(stop: &gtfs_structures::Stop) -> Option<Issue> {
 
 fn has_coord(stop: &gtfs_structures::Stop) -> bool {
     match (stop.latitude, stop.longitude) {
-        (Some(lon), Some(lat)) => lon != 0.0 && lat != 0.0,
+        (Some(lon), Some(lat)) => lon != 0.0 || lat != 0.0,
         _ => false,
     }
 }
@@ -133,7 +131,7 @@ fn test_missing() {
         .collect();
 
     assert_eq!(1, missing_coord_issue.len());
-    assert_eq!("AMV", missing_coord_issue[0].object_id);
+    assert_eq!("null_island", missing_coord_issue[0].object_id);
     assert_eq!(
         IssueType::MissingCoordinates,
         missing_coord_issue[0].issue_type

--- a/test_data/stops/stops.txt
+++ b/test_data/stops/stops.txt
@@ -15,4 +15,6 @@ entrance_bad_parent,bad entrance,,36.909489,-116.768242,,,2,BULLFROG
 good_entrance,good entrance,,36.909489,-116.768242,,,2,PARENT
 EMSI,E Main St / S Irving St (Demo),,36.905697,-116.76218,,,,
 AMV,Amargosa Valley (Demo),,0.0,-116.40094,,,,
+DIJON,Dijon Valley (Demo),,-42.1337,0.0,,,,
+null_island,Null Island,,0.0,0.0,,,,
 PARENT,Moo,,92.462154,-116.40094,,,1,


### PR DESCRIPTION
`MissingCoordinates` was a bit too strict, and `0` was rejected for a stop latitude or longitude.

We now allow a `0` as the latitude XOR (EXCLUSIVE OR) longitude field.

Logged https://github.com/etalab/transport-validator/issues/202 to add further checks for stop coordinates.