### PR TITLE
Add NoCalendar warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,8 @@ Here is a human friendly list of them :
 |                                  |             |                                                                                                                                                                                          |
 | MissingId                        | Error       | An agency, a calendar, a route, a shape point, a stop or a trip has its Id missing.                                                                                                      |
 | MissingUrl                       | Error       | An agency or a feed publisher is missing its URL.                                                                                                                                        |
+| NoCalendar                       | Warning     | The GTFS is empty for both `calendar.txt` and `calendar_dates.txt`. The service is never running.                                                                                        |
+
 | InvalidUrl                       | Error       | The URL of an agency or a feed publisher is not valid.                                                                                                                                   |
 | InvalidCoordinates               | Error       | The coordinates of a shape point or a stop are not valid.                                                                                                                                |
 | InvalidTimezone                  | Error       | The TimeZone of an agency is not valid.                                                                                                                                                  |

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -98,6 +98,9 @@ pub enum IssueType {
     /// A trip must visit more than one stop in stop_times.txt to be usable by passengers for
     /// boarding and alighting.
     UnusableTrip,
+    /// The GTFS is empty for both `calendar.txt` and `calendar_dates.txt`. The service
+    /// is never running.
+    NoCalendar,
 }
 
 /// Represents an object related to another object that is causing an issue.

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -72,6 +72,7 @@ pub fn validate_and_metadata(
                     .chain(validators::route_type::validate(gtfs))
                     .chain(validators::shapes::validate(gtfs))
                     .chain(validators::agency::validate(gtfs))
+                    .chain(validators::calendar::validate(gtfs))
                     .chain(validators::duplicate_stops::validate(gtfs))
                     .chain(validators::fare_attributes::validate(gtfs))
                     .chain(validators::feed_info::validate(gtfs))

--- a/src/validators/calendar.rs
+++ b/src/validators/calendar.rs
@@ -1,0 +1,34 @@
+use crate::issues::*;
+
+pub fn validate(gtfs: &gtfs_structures::Gtfs) -> Vec<Issue> {
+    if gtfs.calendar.len() + gtfs.calendar_dates.len() == 0 {
+        vec![Issue::new(Severity::Warning, IssueType::NoCalendar, "")]
+    } else {
+        vec![]
+    }
+}
+
+#[test]
+fn test_empty() {
+    let gtfs = gtfs_structures::Gtfs::new("test_data/empty_calendar").unwrap();
+    let issues = validate(&gtfs);
+    let warning_issues: Vec<_> = issues
+        .iter()
+        .filter(|issue| issue.severity == Severity::Warning)
+        .collect();
+
+    assert_eq!(1, warning_issues.len());
+    assert_eq!(IssueType::NoCalendar, warning_issues[0].issue_type);
+}
+
+#[test]
+fn test_calendar_is_set() {
+    let gtfs = gtfs_structures::Gtfs::new("test_data/feed_info").unwrap();
+    let issues = validate(&gtfs);
+    let no_calendar_issues: Vec<_> = issues
+        .iter()
+        .filter(|issue| issue.issue_type == IssueType::NoCalendar)
+        .collect();
+
+    assert!(no_calendar_issues.is_empty());
+}

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -1,4 +1,5 @@
 pub mod agency;
+pub mod calendar;
 pub mod check_id;
 pub mod check_name;
 pub mod duplicate_stops;

--- a/test_data/empty_calendar/agency.txt
+++ b/test_data/empty_calendar/agency.txt
@@ -1,0 +1,3 @@
+agency_id,agency_name,agency_url,agency_timezone,agency_lang
+1,"BIBUS",http://www.bibus.fr,Europe/Paris,fr
+2,"Ter",http://www.sncf.com,Europe/Paris,fr

--- a/test_data/empty_calendar/calendar.txt
+++ b/test_data/empty_calendar/calendar.txt
@@ -1,0 +1,1 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date

--- a/test_data/empty_calendar/calendar_dates.txt
+++ b/test_data/empty_calendar/calendar_dates.txt
@@ -1,0 +1,1 @@
+service_id,date,exception_type

--- a/test_data/empty_calendar/fare_attributes.txt
+++ b/test_data/empty_calendar/fare_attributes.txt
@@ -1,0 +1,1 @@
+fare_id,price,currency_type,payment_method,transfers,agency_id,transfer_duration

--- a/test_data/empty_calendar/routes.txt
+++ b/test_data/empty_calendar/routes.txt
@@ -1,0 +1,6 @@
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
+1,848,"","100","",3,,FFFFFF,000000
+2,848,"100","","",42,,111111,FFFFFF
+3,848,"100","","",42,,000000,AAAAAA
+4,848,"100","100","",42,,111111,AAAAAA
+5,848,"100","100","",42,,,

--- a/test_data/empty_calendar/stop_times.txt
+++ b/test_data/empty_calendar/stop_times.txt
@@ -1,0 +1,3 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_time_desc,pickup_type,drop_off_type
+trip1,14:00:00,14:00:00,stop2,0,"",0,1
+trip1,15:00:00,15:00:00,stop3,0,"",2,

--- a/test_data/empty_calendar/stops.txt
+++ b/test_data/empty_calendar/stops.txt
@@ -1,0 +1,6 @@
+stop_id,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,wheelchair_boarding
+stop1,"Stop Area",, 48.796058 ,2.449386,,,1,,
+stop2,"StopPoint",,48.796058,2.449386,,,,,
+stop3,"Stop Point child of 1",,48.796058,2.449386,,,0,1,
+stop4,"StopPoint2",,48.796058,2.449386,,,,,
+stop5,"Stop Point child of 1 bis",,48.796058,2.449386,,,0,1,

--- a/test_data/empty_calendar/trips.txt
+++ b/test_data/empty_calendar/trips.txt
@@ -1,0 +1,2 @@
+route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,block_id,wheelchair_accessible,bikes_allowed,trip_desc,shape_id
+route1,service1,trip1,"85088452",,0,,0,0,,


### PR DESCRIPTION
Fixes #168

Add a new `NoCalendar` warning when both `calendar.txt` and `calendar_dates.txt` are empty, meaning the service is never running.