### PR TITLE
Switch to jemalloc by default (improves prod memory consumption)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,6 +2561,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,6 +2821,7 @@ dependencies = [
  "serde_json",
  "serde_norway",
  "tempfile",
+ "tikv-jemallocator",
  "url",
  "walkdir",
  "zip 2.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -2572,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ actix-web = { version = "4.9", optional = true }
 actix-rt = { version = "2.10", optional = true }
 geojson = "0.24"
 rgb = "0.8"
+tikv-jemallocator = "0.6"
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ actix-web = { version = "4.9", optional = true }
 actix-rt = { version = "2.10", optional = true }
 geojson = "0.24"
 rgb = "0.8"
-tikv-jemallocator = "0.6"
+tikv-jemallocator = "0.7"
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ codegen-units = 1 # Reduce number of codegen units to increase optimizations.
 panic = 'abort'   # Abort on panic
 
 [features]
-default = ["daemon"]
+default = ["daemon", "jemalloc"]
+jemalloc = ["tikv-jemallocator"]
 daemon = ["actix-web", "actix-rt", "futures", "read-url", "env_logger"]
 read-url = ["gtfs-structures/read-url"]
 
@@ -38,7 +39,7 @@ actix-web = { version = "4.9", optional = true }
 actix-rt = { version = "2.10", optional = true }
 geojson = "0.24"
 rgb = "0.8"
-tikv-jemallocator = "0.7"
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/readme.md
+++ b/readme.md
@@ -305,6 +305,12 @@ git clone https://github.com/etalab/transport-validator/
 cd transport-validator
 ```
 
+By default, the project uses [jemalloc](https://jemalloc.net/) as the memory allocator to reduce memory usage in production. jemalloc is not supported on Windows/MSVC. To build without it:
+
+```
+cargo build --no-default-features --features daemon
+```
+
 ## Run the validator
 
 ### Run from a local directory

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -58,6 +58,7 @@ struct Opt {
 fn main() -> Result<(), anyhow::Error> {
     #[cfg(feature = "daemon")]
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    log::info!("Allocator: {}", if cfg!(feature = "jemalloc") { "jemalloc" } else { "system" });
 
     let opt = Opt::parse();
     let custom_rules = custom_rules::custom_rules(opt.custom_rules);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_env = "msvc"))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -58,7 +58,14 @@ struct Opt {
 fn main() -> Result<(), anyhow::Error> {
     #[cfg(feature = "daemon")]
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    log::info!("Allocator: {}", if cfg!(feature = "jemalloc") { "jemalloc" } else { "system" });
+    log::info!(
+        "Allocator: {}",
+        if cfg!(feature = "jemalloc") {
+            "jemalloc"
+        } else {
+            "system"
+        }
+    );
 
     let opt = Opt::parse();
     let custom_rules = custom_rules::custom_rules(opt.custom_rules);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,3 +1,7 @@
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use clap::{Parser, ValueEnum};
 #[cfg(feature = "daemon")]
 use validator::daemon;


### PR DESCRIPTION
EDIT: as expected, it worked out very well.

This is an attempt to solve memory-leak-like (rising memory, never going down) patterns in RAM consumption in production; jemalloc often solves those issues.

To be tested __in production__ before merge (I will deploy there at some point, directly via the branch).

I'm interested by a review though (@antoine-de @Tristramg), if you have time & budget!

References:
- https://github.com/etalab/transport-site/issues/3892
- https://github.com/actix/actix-web/discussions/2775 (mentions jemalloc)

Also:
- https://magiroux.com/rust-jemalloc-profiling jemalloc will help with further memory profiling, if needed
- https://rust-lang.github.io/rfcs/1183-swap-out-jemalloc.html (jemalloc removed as default, but not for reliability problems)

### Production measurements & symptoms

Each app restart changes the colour. The memory consumption only goes up, which is fairly typical of production memory leaks. This is what will help me verify if the fix works or not.

<img width="1140" height="326" alt="CleanShot 2026-06-02 at 11 28 57" src="https://github.com/user-attachments/assets/96896632-d973-4781-93e0-982f2eac2646" />

Also the app is on a regular basis
<img width="786" height="699" alt="CleanShot 2026-06-02 at 11 29 56" src="https://github.com/user-attachments/assets/d3ca7252-e0dd-4734-a292-516aebce3f50" />
